### PR TITLE
The "main multiblock carrier" refers to the initial static carrier

### DIFF
--- a/src/recon_alloc.erl
+++ b/src/recon_alloc.erl
@@ -206,7 +206,7 @@ average_sizes() ->
 %% specific work with mbcs that should help reduce fragmentation in ways
 %% sys_alloc or mmap usually won't.
 %%
-%% Ideally, most of the data should fit inside main multiblock carriers. If
+%% Ideally, most of the data should fit inside multiblock carriers. If
 %% most of the data ends up in `sbcs', you may need to adjust the multiblock
 %% carrier sizes, specifically the maximal value (`lmbcs') and the threshold
 %% (`sbct'). On 32 bit VMs, `sbct' is limited to 8MBs, but 64 bit VMs can go


### PR DESCRIPTION
The main multiblock carrier is adjusted using +M<T>mmbcs and can be used to pre allocate memory to a specific allocator if needed. It can also be used to decrease the pre allocated data for small embedded systems. 
