### PR TITLE
Do not crash when allocator info is missing

### DIFF
--- a/src/recon_alloc.erl
+++ b/src/recon_alloc.erl
@@ -376,8 +376,9 @@ allocators() ->
     %% and never really having come across a case where it was useful to know.
     [{{A,N},lists:sort(proplists:delete(versions,Props))} ||
         A <- Allocators,
-        erlang:system_info({allocator,A}) =/= false,
-        {_,N,Props} <- erlang:system_info({allocator,A})].
+        Allocs <- [erlang:system_info({allocator,A})],
+        Allocs =/= false,
+        {_,N,Props} <- Allocs].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Snapshot handling %%%


### PR DESCRIPTION
Whenever erlang:system_info({allocator, Alloc}) returns false, recon_alloc:allocators/0 crashes with the following error:

```
1> recon_alloc:fragmentation(current).
** exception error: no function clause matching recon_alloc:'-allocators/0-lc$^1/1-1-'(false) (src/recon_alloc.erl, line 377)
     in function  recon_alloc:'-allocators/0-lc$^1/1-1-'/3 (src/recon_alloc.erl, line 379)
     in call from recon_alloc:'-allocators/0-lc$^1/1-1-'/3 (src/recon_alloc.erl, line 379)
     in call from recon_alloc:snapshot_int/0 (src/recon_alloc.erl, line 606)
     in call from recon_alloc:snapshot_get_int/0 (src/recon_alloc.erl, line 612)
     in call from recon_alloc:alloc/0 (src/recon_alloc.erl, line 619)
     in call from recon_alloc:alloc/1 (src/recon_alloc.erl, line 622)
     in call from recon_alloc:fragmentation/1 (src/recon_alloc.erl, line 252)
```
