### PR TITLE
Add Makefile for invocation of dialyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.beam
 erl_crash.dump
 .eunit
+.dialyzer_plt
 /doc/*.html
 /doc/edoc-info
 /doc/erlang.png

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+all:
+.PHONY: all
+
+DIALYZER_PLT = .dialyzer_plt
+
+$(DIALYZER_PLT):
+	dialyzer --build_plt --output_plt $@ --apps erts kernel stdlib crypto compiler syntax_tools
+
+dialyze: $(DIALYZER_PLT)
+	dialyzer --plt $< -Werror_handling --src -r src
+.PHONY: dialyze


### PR DESCRIPTION
Sample run of the new `dialyze` make target in a clean working copy of
a1a8304 with Erlang/OTP 17.0:

```
$ make dialyze
dialyzer --build_plt --output_plt .dialyzer_plt --apps erts kernel stdlib crypto compiler syntax_tools
  Compiling some key modules to native code... done in 1m2.23s
  Creating PLT .dialyzer_plt ...
Unknown functions:
  hipe:compile/4
 done in 2m46.84s
done (passed successfully)
dialyzer --plt .dialyzer_plt -Werror_handling --src -r src
  Checking whether the PLT .dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
recon.erl:200: Overloaded contract for recon:info/2 has overlapping domains; such contracts are currently unsupported and are simply ignored
recon.erl:614: Overloaded contract for recon:port_info/2 has overlapping domains; such contracts are currently unsupported and are simply ignored
 done in 0m3.16s
done (warnings were emitted)
make: *** [dialyze] Error 2
$ echo $?
2
```
