### PR TITLE
Add simple recon_trace:quick/2 for beginners

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -39,7 +39,7 @@
 %%%  |               -,        ,-               |
 %%%   '-,              '-,  ,-'              ,-'
 %%%      '-,_          _,-''-,_          _,-'
-%%%          '--------'        '--------' 
+%%%          '--------'        '--------'
 %%% '''
 %%%
 %%% If either the pid specification excludes a process or a trace pattern
@@ -156,7 +156,7 @@
 -module(recon_trace).
 
 %% API
--export([clear/0, calls/2, calls/3]).
+-export([clear/0, calls/2, calls/3, quick/2]).
 
 %% Internal exports
 -export([count_tracer/1, rate_tracer/2, formatter/3]).
@@ -207,6 +207,24 @@ calls({Mod, Fun, Args}, Max) ->
 calls(TSpecs = [_|_], Max) ->
     calls(TSpecs, Max, []).
 
+%% @doc Allows quick tracing on all calls within a module without resorting
+%% to complex trace patterns.
+%%
+%% Parameters are `Module' and `Scope' where:
+%%
+%% <ul>
+%%   <li>`Module' is an atom representing a currently loaded module</li>
+%%   <li>`Scope' is either a maximum count of traces before stopping, or
+%%   a tuple representing the frequency of traces/millisecond before stopping,
+%%   for example `{1,1000}' meaning maximum 1 trace/second.</li>
+%% </ul>
+%%
+%% For example, `recon_trace:quick(queue, 5)' traces the next 5 calls to the
+%% queue module.
+-spec quick(module(), max()) -> num_matches().
+quick(Module, Max) ->
+              calls({Module, '_', '_'}, Max, [{pid, all}, {scope, local}]).
+
 %% @doc Allows to set trace patterns and pid specifications to trace
 %% function calls.
 %%
@@ -228,7 +246,7 @@ calls(TSpecs = [_|_], Max) ->
 %% of trace messages to be received, or a maximal frequency (`{Num, Millisecs}').
 %%
 %% Here are examples of things to trace:
-%% 
+%%
 %% <ul>
 %%  <li>All calls from the `queue' module, with 10 calls printed at most:
 %%      ``recon_trace:calls({queue, '_', '_'}, 10)''</li>
@@ -577,4 +595,4 @@ fun_to_ms(ShellFun) when is_function(ShellFun) ->
             end;
         false ->
             exit(shell_funs_only)
-    end. 
+    end.


### PR DESCRIPTION
It's a big leap for a newcomer to tracing to go straight to `recon_trace:calls/3` and friends. This should allow even newcomers to Erlang to use tracing from even the earliest days.

I can revert the whitespace pruning if that's important to you.

The change produces no more dialyzer whining than the current code.