### PR TITLE
add trace to pid other than group_leader()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ all stable changes of the first version of Recon.
     `recon:proc_window`.
   - Fix doc typos
   - Fix potential race condition on waiting for death of tracing process
+  - Add an option which allows sending tracing output somewhere other than
+    group_leader().
 - 2.2.1
   - Fixing type specs for `recon:port_types/0` and `recon_lib:count/1`,
     thanks to @lucafavatella


### PR DESCRIPTION
I found I need to do this today to capture some traces for a few hours to a file.  I'm not sure if there was another way to do this, but this works for me and may be useful for others.