### PR TITLE
Translate proc_lib initial_call attributes

### DIFF
--- a/src/recon.app.src
+++ b/src/recon.app.src
@@ -1,6 +1,6 @@
 {application, recon,
  [{description, "Diagnostic tools for production use"},
-  {vsn, "2.2.2"},
+  {vsn, "2.2.3"},
   {modules, [recon, recon_alloc, recon_lib, recon_trace]},
   {registered, []},
   {applications, [kernel, stdlib]}]}.


### PR DESCRIPTION
Instead of returning vague {proc_lib, init_p, 5} initial_call process
info entries, try to translate them into real initial calls using
proc_lib:initial_call/1
