### PR TITLE
bad match when no usage upon  the scheduler

### DIFF
--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -218,7 +218,8 @@ time_fold(N, Interval, Fun, State, FoldFun, Init) ->
     TotalTime :: non_neg_integer().
 scheduler_usage_diff(First, Last) ->
     lists:map(
-        fun({{I, A0, T0}, {I, A1, T1}}) -> {I, (A1 - A0)/(T1 - T0)} end,
+        fun ({{I, A, T}, {I, A, T}})->{I,0} ;
+        ({{I, A0, T0}, {I, A1, T1}}) -> {I, (A1 - A0)/(T1 - T0)} end,
         lists:zip(lists:sort(First), lists:sort(Last))
     ).
 


### PR DESCRIPTION
19:41:25.270 [error] Supervisor recon_web_sup had child recon_server started with recon_server:start_link() at <0.496.0> exit with reason bad arithmetic expression in recon_lib:'-scheduler_usage_diff/2-fun-0-'/1 line 221 in context child_terminated

i found that exception  when  i try to  make this application work under the  windows  for  my debuging env