### PR TITLE
Fix gc_* trace message information

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -540,14 +540,17 @@ format(TraceMsg) ->
         %% {trace, Pid, gc_start, Info}
         {gc_start, [Info]} ->
             HeapSize = proplists:get_value(heap_size, Info),
-            {"gc beginning -- heap ~p bytes", [HeapSize]};
+            OldHeapSize = proplists:get_value(old_heap_size, Info),
+            MbufSize = proplists:get_value(mbuf_size, Info),
+            {"gc beginning -- heap ~p bytes",
+             [HeapSize + OldHeapSize + MbufSize]};
         %% {trace, Pid, gc_end, Info}
         {gc_end, [Info]} ->
-            [Info] = TraceInfo,
             HeapSize = proplists:get_value(heap_size, Info),
             OldHeapSize = proplists:get_value(old_heap_size, Info),
-            {"gc finished -- heap ~p bytes (recovered ~p bytes)",
-             [HeapSize, OldHeapSize-HeapSize]};
+            MbufSize = proplists:get_value(mbuf_size, Info),
+            {"gc finished -- heap ~p bytes",
+             [HeapSize + OldHeapSize + MbufSize]};
         _ ->
             {"unknown trace type ~p -- ~p", [Type, TraceInfo]}
     end,


### PR DESCRIPTION
I was looking through the recon_trace code and found that what the tracer prints for heap size is in-accurate, and the value it uses as reclaimed is completely wrong. I couldn't find a way to use recon to enable gc tracing, but I did:

```erlang
1> recon_trace:calls({lists,any,2},10,[{pid,self()}]).
1
2> erlang:trace(self(), true, [{tracer, element(2,erlang:trace_info(self(),tracer))}, garbage_collection]).
1
3> erlang:trace_info(self(), flags).
{flags,[garbage_collection,call]}
   
16:34:43.081556 <0.34.0> gc beginning -- heap 3067 bytes
   
16:34:43.083763 <0.34.0> gc finished -- heap 539 bytes
```

and it seems to work.