### PR TITLE
Avoid divide by zero in scheduler_usage/1 on lightly loaded systems.

### DIFF
--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -218,7 +218,9 @@ time_fold(N, Interval, Fun, State, FoldFun, Init) ->
     TotalTime :: non_neg_integer().
 scheduler_usage_diff(First, Last) ->
     lists:map(
-        fun({{I, A0, T0}, {I, A1, T1}}) -> {I, (A1 - A0)/(T1 - T0)} end,
+        fun ({{I, _A0, T}, {I, _A1, T}}) -> {I, 0.0}; % Avoid divide by zero
+            ({{I, A0, T0}, {I, A1, T1}}) -> {I, (A1 - A0)/(T1 - T0)}
+        end,
         lists:zip(lists:sort(First), lists:sort(Last))
     ).
 

--- a/test/recon_lib_SUITE.erl
+++ b/test/recon_lib_SUITE.erl
@@ -1,0 +1,17 @@
+-module(recon_lib_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-compile(export_all).
+
+all() -> [scheduler_usage_diff].
+
+scheduler_usage_diff(_Config) ->
+    {Active0, Total0} = {1000, 2000},
+    SchedStat0 = {1, Active0, Total0},
+    % No active or total time has elapsed. Make sure we don't divide by zero.
+    [{1, 0.0}] = recon_lib:scheduler_usage_diff([SchedStat0], [SchedStat0]),
+    % Total time has elapsed, but no active time. Make sure we get 0 usage back.
+    SchedStat1 = {1, Active0, Total0 * 2},
+    [{1, 0.0}] = recon_lib:scheduler_usage_diff([SchedStat0], [SchedStat1]),
+    % Check for 100% usage
+    SchedStat2 = {1, Active0 + 1000, Total0 + 1000},
+    [{1, 1.0}] = recon_lib:scheduler_usage_diff([SchedStat0], [SchedStat2]).


### PR DESCRIPTION
Fix for #35 

Also added the dumbest possible test suite. I can remove this module if you'd prefer.