### PR TITLE
add trace helper

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -470,6 +470,10 @@ validate_pid_specs(PidTerm) ->
 
 validate_tspec(Mod, Fun, Args) when is_function(Args) ->
     validate_tspec(Mod, Fun, fun_to_ms(Args));
+%% helper to save typing for common actions
+validate_tspec(Mod, Fun, trace) ->
+    validate_tspec(Mod, Fun,
+                   fun_to_ms(fun(_) -> return_trace() end));
 validate_tspec(Mod, Fun, Args) ->
     BannedMods = ['_', ?MODULE, io, lists],
     %% The banned mod check can be bypassed by using


### PR DESCRIPTION
I find myself typing the following a lot:
```erlang
recon_trace:calls({mod, func, fun(_) -> return_trace() end}, 2).
```
So I added a helper in validation (the atom  `trace` in the place of the arg fun) that is replaced with the above function.  It may need a better name.