### PR TITLE
Don't throw an exception when erlang:statistics(scheduler_wall_time) …

### DIFF
--- a/src/recon.erl
+++ b/src/recon.erl
@@ -348,7 +348,7 @@ node_stats_print(N, Interval) ->
 %% </ul>
 %%
 %% A scheduler isn't busy when doing anything else.
--spec scheduler_usage(Millisecs) -> [{SchedulerId, Usage}] when
+-spec scheduler_usage(Millisecs) -> undefined | [{SchedulerId, Usage}] when
     Millisecs :: non_neg_integer(),
     SchedulerId :: pos_integer(),
     Usage :: number().

--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -211,12 +211,14 @@ time_fold(N, Interval, Fun, State, FoldFun, Init) ->
 
 %% @doc Diffs two runs of erlang:statistics(scheduler_wall_time) and
 %% returns usage metrics in terms of cores and 0..1 percentages.
--spec scheduler_usage_diff(SchedTime, SchedTime) -> [{SchedulerId, Usage}] when
+-spec scheduler_usage_diff(SchedTime, SchedTime) -> undefined | [{SchedulerId, Usage}] when
     SchedTime :: [{SchedulerId, ActiveTime, TotalTime}],
     SchedulerId :: pos_integer(),
     Usage :: number(),
     ActiveTime :: non_neg_integer(),
     TotalTime :: non_neg_integer().
+scheduler_usage_diff(First, Last) when First =:= undefined orelse Last =:= undefined ->
+    undefined;
 scheduler_usage_diff(First, Last) ->
     lists:map(
         fun ({{I, _A0, T}, {I, _A1, T}}) -> {I, 0.0}; % Avoid divide by zero


### PR DESCRIPTION
…returns undefined

This is possible, according to the erlang:statistics documentation, but it's not being handled.
It occurs seldom and the only way to protect against it is by using the not-so-elegant try-catch
approach.