### PR TITLE
Add binary support to recon_lib:term_to_pid/1

### DIFF
--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -150,6 +150,7 @@ triple_to_pid(X, Y, Z) ->
 term_to_pid(Pid) when is_pid(Pid) -> Pid;
 term_to_pid(Name) when is_atom(Name) -> whereis(Name);
 term_to_pid(List = "<0."++_) -> list_to_pid(List);
+term_to_pid(Binary = <<"<0.", _/binary>>) -> list_to_pid(binary_to_list(Binary));
 term_to_pid({global, Name}) -> global:whereis_name(Name);
 term_to_pid({via, Module, Name}) -> Module:whereis_name(Name);
 term_to_pid({X,Y,Z}) when is_integer(X), is_integer(Y), is_integer(Z) ->

--- a/test/recon_lib_SUITE.erl
+++ b/test/recon_lib_SUITE.erl
@@ -2,7 +2,7 @@
 -include_lib("common_test/include/ct.hrl").
 -compile(export_all).
 
-all() -> [scheduler_usage_diff, sublist_top_n].
+all() -> [scheduler_usage_diff, sublist_top_n, term_to_pid].
 
 scheduler_usage_diff(_Config) ->
     {Active0, Total0} = {1000, 2000},
@@ -26,4 +26,22 @@ sublist_top_n(_Config) ->
         ct:pal("Sub ~p: ~p", [N, Sub]),
         Sub = (catch recon_lib:sublist_top_n_attrs(L, N))
      end || N <- lists:seq(0, length(L)+1)],
+    ok.
+
+term_to_pid(_Config) ->
+    Pid = self(),
+    Pid = recon_lib:term_to_pid(Pid),
+    List = pid_to_list(Pid),
+    Pid = recon_lib:term_to_pid(List),
+    Binary = list_to_binary(List),
+    Pid = recon_lib:term_to_pid(Binary),
+    Name = foo,
+    register(Name, Pid),
+    Pid = recon_lib:term_to_pid(Name),
+    yes = global:register_name(Name, Pid),
+    Pid = recon_lib:term_to_pid({global, Name}),
+    Sublist = lists:sublist(List, 2, length(List)-2),
+    Ints = [ element(1, string:to_integer(T)) || T <- string:tokens(Sublist, ".")],
+    Triple = list_to_tuple(Ints),
+    Pid = recon_lib:term_to_pid(Triple),
     ok.


### PR DESCRIPTION
Thanks to recon I was able to track down my first memory leak in production so thanks for writing this library!

Now for some context: I'm running elixir in production and this was a tiny stumbling stone when figuring out how to specify a pid when using `recon_trace.calls/3`. In erlang you'd probably never represent a pid as a binary so while this change certainly isn't necessary, I think it also doesn't hurt. It could also save the next guy from getting a "no function clause matching" error when attempting to use recon from elixir:
```
iex(4)> :recon_trace.calls {:prim_inet, :send, fn _ -> :return_trace end}, 10, pid: "<0.2342.45>"
** (FunctionClauseError) no function clause matching in :recon_lib.term_to_pid/1
```
I added a few tests for `recon_lib:term_to_pid/1`. It's not typical for a ct test, I'm aware. I'm open to suggestions there if you have them.
