### PR TITLE
Fix quoting in documentation string.

### DIFF
--- a/src/recon_alloc.erl
+++ b/src/recon_alloc.erl
@@ -380,7 +380,7 @@ allocators() ->
 %% @doc returns a dump of all allocator settings and values modified
 %%      depending on the argument.
 %% <ul>
-%%   <li>`types` report the settings and accumulated values for each
+%%   <li>`types' report the settings and accumulated values for each
 %%       allocator type. This is useful when looking for anomalies
 %%       in the system as a whole and not specific instances.</li>
 %% </ul>


### PR DESCRIPTION
A small fix for this build error:

    ./src/recon_alloc.erl, function allocators/1: at line 383: `-quote ended unexpectedly at line 386
    edoc: skipping source file './src/recon_alloc.erl': {'EXIT',error}.
    edoc: error in doclet 'edoc_doclet': {'EXIT',error}.
    ERROR: doc failed while processing /wrkdirs/usr/ports/devel/erlang-recon/work/recon-2.3.3: {'EXIT',error}
    *** Error code 1
