### PR TITLE
Formatting records according to their definitions

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -41,6 +41,12 @@ Included modules are:
         Provides production-safe tracing facilities, to dig into the
         execution of programs and function calls as they are running.
     </dd>
+
+    <dt>{@link recon_rec}</dt>
+    <dd>
+        An extension to recon_trace, enables printing out records in a more readable format
+        based on known record definitions.
+    </dd>
 </dl>
 
 This library contains few tests -- most of the functionality has been

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {profiles, [
     {test, [
-        {erl_opts, [nowarn_export_all]}
+        {erl_ops, [nowarn_expor_all, {d, 'TEST'}]}
     ]}
 ]}.

--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -13,7 +13,8 @@
          term_to_port/1,
          time_map/5, time_fold/6,
          scheduler_usage_diff/2,
-         sublist_top_n_attrs/2, format_trace_output/1]).
+         sublist_top_n_attrs/2,
+         format_trace_output/1, format_trace_output/2]).
 %% private exports
 -export([binary_memory/1]).
 
@@ -248,16 +249,19 @@ binary_memory(Bins) ->
 %% @doc formats call arguments and return values - most types are just printed out, except for
 %% tuples recognised as records, which mimic the source code syntax
 %% @end
-format_trace_output(Args) when is_tuple(Args) ->
+format_trace_output(Args) ->
+    format_trace_output(recon_rec:is_active(), Args).
+
+format_trace_output(true, Args) when is_tuple(Args) ->
     recon_rec:format_tuple(Args);
-format_trace_output(Args) when is_list(Args) ->
+format_trace_output(true, Args) when is_list(Args) ->
     case io_lib:printable_list(Args) of
         true -> io_lib:format("~p", [Args]);
         false ->
-            L = lists:map(fun format_trace_output/1, Args),
+            L = lists:map(fun(A) -> format_trace_output(true, A) end, Args),
             "[" ++ string:join(L, ", ") ++ "]"
     end;
-format_trace_output(Args) ->
+format_trace_output(_, Args) ->
     io_lib:format("~p", [Args]).
 
 %%%%%%%%%%%%%%%

--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -13,7 +13,7 @@
          term_to_port/1,
          time_map/5, time_fold/6,
          scheduler_usage_diff/2,
-         sublist_top_n_attrs/2]).
+         sublist_top_n_attrs/2, format/1]).
 %% private exports
 -export([binary_memory/1]).
 
@@ -245,6 +245,18 @@ sublist_top_n_attrs(List, Len) ->
 binary_memory(Bins) ->
     lists:foldl(fun({_,Mem,_}, Tot) -> Mem+Tot end, 0, Bins).
 
+format(Args) when is_tuple(Args) ->
+    recon_rec:format_tuple(Args);
+format(Args) when is_list(Args) ->
+    case is_printable(Args) of
+        true -> io_lib:format("~p", [Args]);
+        false ->
+            L = lists:map(fun format/1, Args),
+            "[" ++ string:join(L, ", ") ++ "]"
+    end;
+format(Args) ->
+    io_lib:format("~p", [Args]).
+
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%
 %%%%%%%%%%%%%%%
@@ -281,3 +293,6 @@ merge(H1, [E2|H2]) -> [E2, H1|H2].
 merge_pairs([]) -> [];
 merge_pairs([H]) -> H;
 merge_pairs([A, B|T]) -> merge(merge(A, B), merge_pairs(T)).
+
+is_printable(List) ->
+    lists:all(fun(I) -> I > 31 andalso I < 128 end, List).

--- a/src/recon_lib.erl
+++ b/src/recon_lib.erl
@@ -13,7 +13,7 @@
          term_to_port/1,
          time_map/5, time_fold/6,
          scheduler_usage_diff/2,
-         sublist_top_n_attrs/2, format/1]).
+         sublist_top_n_attrs/2, format_trace_output/1]).
 %% private exports
 -export([binary_memory/1]).
 
@@ -245,16 +245,19 @@ sublist_top_n_attrs(List, Len) ->
 binary_memory(Bins) ->
     lists:foldl(fun({_,Mem,_}, Tot) -> Mem+Tot end, 0, Bins).
 
-format(Args) when is_tuple(Args) ->
+%% @doc formats call arguments and return values - most types are just printed out, except for
+%% tuples recognised as records, which mimic the source code syntax
+%% @end
+format_trace_output(Args) when is_tuple(Args) ->
     recon_rec:format_tuple(Args);
-format(Args) when is_list(Args) ->
-    case is_printable(Args) of
+format_trace_output(Args) when is_list(Args) ->
+    case io_lib:printable_list(Args) of
         true -> io_lib:format("~p", [Args]);
         false ->
-            L = lists:map(fun format/1, Args),
+            L = lists:map(fun format_trace_output/1, Args),
             "[" ++ string:join(L, ", ") ++ "]"
     end;
-format(Args) ->
+format_trace_output(Args) ->
     io_lib:format("~p", [Args]).
 
 %%%%%%%%%%%%%%%
@@ -294,5 +297,4 @@ merge_pairs([]) -> [];
 merge_pairs([H]) -> H;
 merge_pairs([A, B|T]) -> merge(merge(A, B), merge_pairs(T)).
 
-is_printable(List) ->
-    lists:all(fun(I) -> I > 31 andalso I < 128 end, List).
+

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -14,6 +14,7 @@
 -author("bartlomiej.gorny@erlang-solutions.com").
 %% API
 
+-export([is_active/0]).
 -export([import/1, format_tuple/1, clear/1, clear/0, list/0, get_list/0, limit/3]).
 
 -export([lookup_record/2]). %% for testing
@@ -40,6 +41,14 @@ import(Modules) when is_list(Modules) ->
     lists:foldl(fun import/2, [], Modules);
 import(Module) ->
     import(Module, []).
+
+%% @doc quickly check if we want to do any record formatting
+-spec is_active() -> boolean().
+is_active() ->
+    case whereis(recon_ets) of
+        undefined -> false;
+        _ -> true
+    end.
 
 %% @doc remove definitions imported from a module.
 clear(Module) ->
@@ -181,7 +190,7 @@ format_tuple(Name, Rec) when is_atom(Name) ->
         [RecDef] -> format_record(Rec, RecDef);
         _ ->
             List = tuple_to_list(Rec),
-            ["{", lists:join(", ", [recon_lib:format_trace_output(El) || El <- List]), "}"]
+            ["{", lists:join(", ", [recon_lib:format_trace_output(true, El) || El <- List]), "}"]
     end;
 format_tuple(_, Tuple) ->
     format_default(Tuple).
@@ -204,7 +213,7 @@ format_record(Rec, {{Name, Arity}, Fields, _, Limits}) ->
     end.
 
 format_kv(Key, Val) ->
-    [recon_lib:format_trace_output(Key), "=", recon_lib:format_trace_output(Val)].
+    [recon_lib:format_trace_output(true, Key), "=", recon_lib:format_trace_output(true, Val)].
 
 apply_limits(List, all) -> List;
 apply_limits(_List, none) -> [];

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -69,7 +69,7 @@ clear() ->
 list() ->
     F = fun({Module, Name, Fields, Limits}) ->
             Fnames = lists:map(fun atom_to_list/1, Fields),
-            Flds = string:join(Fnames, ", "),
+            Flds = join(",", Fnames),
             io:format("~p: #~p(~p){~s} ~p~n", [Module, Name, length(Fields), Flds, Limits])
         end,
     lists:foreach(F, get_list()).
@@ -194,7 +194,7 @@ format_tuple(Name, Rec) when is_atom(Name) ->
         [RecDef] -> format_record(Rec, RecDef);
         _ ->
             List = tuple_to_list(Rec),
-            ["{", lists:join(", ", [recon_trace:format_trace_output(true, El) || El <- List]), "}"]
+            ["{", join(", ", [recon_trace:format_trace_output(true, El) || El <- List]), "}"]
     end;
 format_tuple(_, Tuple) ->
     format_default(Tuple).
@@ -210,7 +210,7 @@ format_record(Rec, {{Name, Arity}, Fields, _, Limits}) ->
             List = lists:zip(Fields, Values),
             LimitedList = apply_limits(List, Limits),
             ["#", atom_to_list(Name), "{",
-             lists:join(", ", [format_kv(Key, Val) || {Key, Val} <- LimitedList]),
+             join(", ", [format_kv(Key, Val) || {Key, Val} <- LimitedList]),
              "}"];
         _ ->
             format_default(Rec)
@@ -249,3 +249,12 @@ wait_for_death(Pid, Name) ->
             ok
     end.
 
+-ifdef(OTP_RELEASE).
+-spec join(term(), [term()]) -> [term()].
+join(Sep, List) ->
+    lists:join(Sep, List).
+-else.
+-spec join(string(), [string()]) -> string().
+join(Sep, List) ->
+    string:join(List, Sep).
+-endif.

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -87,7 +87,7 @@ make_list_entry({{Name, _}, Fields, Module, Limits}) ->
                    [] -> all;
                    Other -> Other
                end,
-    {Module, Name, field_names(Fields), FmtLimit}.
+    {Module, Name, Fields, FmtLimit}.
 
 import(Module, ResultList) ->
     ensure_table_exists(),
@@ -141,7 +141,7 @@ ensure_table_exists() ->
 ets_table_name() -> recon_record_definitions.
 
 rec_info({Name, Fields}, Module) ->
-    {{Name, length(Fields)}, Fields, Module, []}.
+    {{Name, length(Fields)}, field_names(Fields), Module, []}.
 
 rem_for_module({_, _, Module, _} = Rec, Module) ->
     ets:delete_object(ets_table_name(), Rec);
@@ -182,8 +182,7 @@ format_record(Rec, {{Name, Arity}, Fields, _, Limits}) ->
     case tuple_size(Rec) of
         ExpectedLength ->
             [_ | Values] = tuple_to_list(Rec),
-            FieldNames = field_names(Fields),
-            List = lists:zip(FieldNames, Values),
+            List = lists:zip(Fields, Values),
             LimitedList = apply_limits(List, Limits),
             "#" ++ atom_to_list(Name) ++ "{"
                 ++ lists:join(", ", [format_kv(Key, Val) || {Key, Val} <- LimitedList]) ++ "}";

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -56,8 +56,7 @@ clear(Module) ->
 
 %% @doc remove all imported definitions, destroy the table, clean up
 clear() ->
-    catch ets:delete_all_objects(ets_table_name()),
-    catch whereis(recon_ets) ! stop,
+    recon_lib:maybe_kill(recon_ets),
     ok.
 
 %% @doc prints out all "known" (imported) record definitions and their limit settings.

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -169,7 +169,7 @@ format_tuple(Name, Rec) when is_atom(Name) ->
         [RecDef] -> format_record(Rec, RecDef);
         _ ->
             List = tuple_to_list(Rec),
-            "{" ++ string:join([recon_lib:format_trace_output(El) || El <- List], ", ") ++ "}"
+            "{" ++ lists:join(", ", [recon_lib:format_trace_output(El) || El <- List]) ++ "}"
     end;
 format_tuple(_, Tuple) ->
     format_default(Tuple).
@@ -186,13 +186,13 @@ format_record(Rec, {{Name, Arity}, Fields, _, Limits}) ->
             List = lists:zip(FieldNames, Values),
             LimitedList = apply_limits(List, Limits),
             "#" ++ atom_to_list(Name) ++ "{"
-                ++ string:join([format_kv(Key, Val) || {Key, Val} <- LimitedList], ", ") ++ "}";
+                ++ lists:join(", ", [format_kv(Key, Val) || {Key, Val} <- LimitedList]) ++ "}";
         _ ->
             format_default(Rec)
     end.
 
 format_kv(Key, Val) ->
-    recon_lib:format_trace_output(Key) ++ "=" ++ recon_lib:format_trace_output(Val).
+    [recon_lib:format_trace_output(Key), "=", recon_lib:format_trace_output(Val)].
 
 apply_limits(List, []) -> List;
 apply_limits(List, Limits) ->

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -79,7 +79,10 @@ get_list() ->
     Lst = lists:map(fun make_list_entry/1, ets:tab2list(ets_table_name())),
     lists:sort(Lst).
 
-%% @doc Limit output to selected fields of a record (can be 'all', 'none', a field or a list of fields).
+%% @doc Limit output to selected fields of a record (can be 'none', 'all', a field or a list of fields).
+%% Limit set to 'none' means there is no limit, and all fields are displayed; limit 'all' means that
+%% all fields are squashed and only record name will be shown.
+%% @end
 -spec limit(record_name(), arity(), limit()) -> ok | {error, record_unknown}.
 limit(Name, Arity, Limit) ->
     case lookup_record(Name, Arity) of
@@ -104,7 +107,7 @@ format_tuple(Tuple) ->
 
 make_list_entry({{Name, _}, Fields, Module, Limits}) ->
     FmtLimit = case Limits of
-                   [] -> all;
+                   [] -> none;
                    Other -> Other
                end,
     {Module, Name, Fields, FmtLimit}.
@@ -161,7 +164,7 @@ ensure_table_exists() ->
 ets_table_name() -> recon_record_definitions.
 
 rec_info({Name, Fields}, Module) ->
-    {{Name, length(Fields)}, field_names(Fields), Module, all}.
+    {{Name, length(Fields)}, field_names(Fields), Module, none}.
 
 rem_for_module({_, _, Module, _} = Rec, Module) ->
     ets:delete_object(ets_table_name(), Rec);
@@ -214,8 +217,8 @@ format_record(Rec, {{Name, Arity}, Fields, _, Limits}) ->
 format_kv(Key, Val) ->
     [recon_lib:format_trace_output(true, Key), "=", recon_lib:format_trace_output(true, Val)].
 
-apply_limits(List, all) -> List;
-apply_limits(_List, none) -> [];
+apply_limits(List, none) -> List;
+apply_limits(_List, all) -> [];
 apply_limits(List, Field) when is_atom(Field) ->
     [{Field, proplists:get_value(Field, List)}, {more, '...'}];
 apply_limits(List, Limits) ->

--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -1,0 +1,186 @@
+%%%-------------------------------------------------------------------
+%%% @author bartlomiej.gorny@erlang-solutions.com
+%%% @doc
+%%% This module handles formatting records for known record types.
+%%% Record definitions are imported from modules by user. Definitions are
+%%% distinguished by record name and its arity, if you have multiple records
+%%% of the same name and size, you must be careful.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(recon_rec).
+-author("bartlomiej.gorny@erlang-solutions.com").
+%% API
+
+-export([import/1, format_tuple/1, clear/1, clear/0, list/0, limit/3]).
+
+-export([lookup_record/2]). %% for testing
+
+%% @doc import record definitions from a module. If a record definition of the same name
+%% and arity has already been imported from another module then a warning is issued and the new
+%% definition is ignored. You have to choose one and possibly remove the old one using
+%% clear/1. Supports importing multiple modules at once (by giving a list of atoms as
+%% an argument).
+%% @end
+import(Modules) when is_list(Modules) ->
+    lists:map(fun import/1, Modules);
+import(Module) ->
+    ensure_table_exists(),
+    Res = lists:map(fun(Rec) -> store_record(Rec, Module) end,
+                    get_record_defs(Module)),
+    lists:all(fun(I) -> I == ok end, Res).
+
+%% @private if a tuple is a known record, formats is as "#recname{field=value}", otherwise returns
+%% just a printout of a tuple.
+format_tuple(Tuple) ->
+    ensure_table_exists(),
+    First = element(1, Tuple),
+    lists:flatten(format_tuple(First, Tuple)).
+
+%% @doc remove definitions imported from a module.
+clear(Module) ->
+    lists:map(fun(R) -> rem_for_module(R, Module) end, ets:tab2list(ets_table_name())).
+
+%% @doc remove all imported definitions
+clear() ->
+    catch ets:delete_all_objects(ets_table_name()).
+
+%% @doc prints out all "known" (imported) record definitions and their limit settings.
+%% Print out tells module a record originates from, its name and a list of field names,
+%% plus the record's arity (may be handy if handling big records) and a list of field it
+%% limits its output to, if set.
+%% @end
+list() ->
+    ensure_table_exists(),
+    FmtLimit = fun([]) -> all; (List) -> List end,
+    F = fun({Module, Name, Fields, Limits}) ->
+            Fnames = lists:map(fun atom_to_list/1, field_names(Fields)),
+            Flds = string:join(Fnames, ", "),
+            io:format("~p: #~p{~s} (~p) ~p~n", [Module, Name, Flds, length(Fields), FmtLimit(Limits)])
+        end,
+    Lst = [{Module, Name, Fields, Limits} || {{Name, _}, Fields, Module, Limits} <- ets:tab2list(ets_table_name())],
+    lists:foreach(F, lists:sort(Lst)).
+
+%% @doc Limit output to selected fields of a record (set to 'all' to reset).
+limit(Name, Arity, all) ->
+    limit(Name, Arity, []);
+limit(Name, Arity, Field) when is_atom(Field) ->
+    limit(Name, Arity, [Field]);
+limit(Name, Arity, FieldList) ->
+    case lookup_record(Name, Arity) of
+        [] ->
+            io:format("~nRecord ~p/~p not imported~n~n", [Name, Arity]),
+            {error, record_unknown};
+        [{Key, Fields, Mod, _}] ->
+            ets:insert(ets_table_name(), {Key, Fields, Mod, FieldList}),
+            ok
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% PRIVATE
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+store_record(Rec, Module) ->
+    {Name, Fields} = Rec,
+    Arity = length(Fields),
+    case lookup_record(Name, Arity) of
+        [] ->
+            io:format("importing ~p:~p/~p~n", [Module, Name, Arity]),
+            ets:insert(ets_table_name(), rec_info(Rec, Module)),
+            ok;
+        [{_, _, Module, _}] ->
+            io:format("importing ~p:~p/~p~n", [Module, Name, Arity]),
+            ets:insert(ets_table_name(), rec_info(Rec, Module)),
+            ok;
+        [{_, _, Mod, _}] ->
+            io:format("~nWARNING: record ~p/~p already present (imported from ~p), ignoring~n~n",
+                      [Name, Arity, Mod]),
+            failed
+    end.
+
+get_record_defs(Module) ->
+    Path = code:which(Module),
+    {ok,{_,[{abstract_code,{_,AC}}]}} = beam_lib:chunks(Path, [abstract_code]),
+    lists:foldl(fun get_record/2, [], AC).
+
+get_record({attribute, _, record, Rec}, Acc) -> [Rec | Acc];
+get_record(_, Acc) -> Acc.
+
+%% @private
+lookup_record(RecName, FieldCount) ->
+    ensure_table_exists(),
+    ets:lookup(ets_table_name(), {RecName, FieldCount}).
+
+ensure_table_exists() ->
+    case ets:info(ets_table_name()) of
+        undefined ->
+            Pid = case whereis(recon_ets) of
+                      undefined ->
+                          P = spawn(fun() -> ets_keeper() end),
+                          register(recon_ets, P),
+                          P;
+                      P -> P
+                  end,
+            ets:new(ets_table_name(), [set, public, named_table]),
+            ets:give_away(ets_table_name(), Pid, none);
+        _ -> ok
+    end.
+
+ets_table_name() -> recon_record_definitions.
+
+rec_info({Name, Fields}, Module) ->
+    {{Name, length(Fields)}, Fields, Module, []}.
+
+rem_for_module({_, _, Module, _} = Rec, Module) ->
+    ets:delete_object(ets_table_name(), Rec);
+rem_for_module(_, _) -> ok.
+
+ets_keeper() ->
+    receive
+        stop -> ok;
+        _ -> ets_keeper()
+    end.
+
+field_names(Fields) ->
+    lists:map(fun field_name/1, Fields).
+
+field_name({record_field, _, {atom, _, Name}}) -> Name;
+field_name({record_field, _, {atom, _, Name}, _Default}) -> Name;
+field_name({typed_record_field, Field, _Type}) -> field_name(Field).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% FORMATTER
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+format_tuple(Name, Rec) when is_atom(Name) ->
+    case lookup_record(Name, size(Rec) - 1) of
+        [RecDef] -> format_record(Rec, RecDef);
+        _ ->
+            List = tuple_to_list(Rec),
+            "{" ++ string:join([recon_lib:format(El) || El <- List], ", ") ++ "}"
+    end;
+format_tuple(_, Tuple) ->
+    format_default(Tuple).
+
+format_default(Val) ->
+    io_lib:format("~p", [Val]).
+
+format_record(Rec, {{Name, _}, Fields, _, Limits}) ->
+    ExpectedLength = length(Fields) + 1,
+    case size(Rec) of
+        ExpectedLength ->
+            [_ | Values] = tuple_to_list(Rec),
+            FieldNames = field_names(Fields),
+            List = lists:zip(FieldNames, Values),
+            LimitedList = apply_limits(List, Limits),
+            "#" ++ atom_to_list(Name) ++ "{"
+                ++ string:join([format_kv(Key, Val) || {Key, Val} <- LimitedList], ", ") ++ "}";
+        _ ->
+            format_default(Rec)
+    end.
+
+format_kv(Key, Val) ->
+    recon_lib:format(Key) ++ "=" ++ recon_lib:format(Val).
+
+apply_limits(List, []) -> List;
+apply_limits(List, Limits) ->
+    lists:filter(fun({K, _}) -> lists:member(K, Limits) end, List) ++ [{more, '...'}].

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -601,7 +601,7 @@ format_args(Arity) when is_integer(Arity) ->
     ["/", integer_to_list(Arity)];
 format_args(Args) when is_list(Args) ->
     Active = recon_rec:is_active(),
-    ["(", lists:join(", ", [format_trace_output(Active, Arg) || Arg <- Args]), ")"].
+    ["(", join(", ", [format_trace_output(Active, Arg) || Arg <- Args]), ")"].
 
 
 %% @doc formats call arguments and return values - most types are just printed out, except for
@@ -617,12 +617,12 @@ format_trace_output(true, Args) when is_list(Args) ->
         true -> io_lib:format("~p", [Args]);
         false ->
             L = lists:map(fun(A) -> format_trace_output(true, A) end, Args),
-            "[" ++ string:join(L, ", ") ++ "]"
+            "[" ++ join(", ", L) ++ "]"
     end;
 format_trace_output(true, Args) when is_map(Args) ->
     ItemList = maps:to_list(Args),
     ["#{",
-        lists:join(", ", [format_kv(Key, Val) || {Key, Val} <- ItemList]),
+        join(", ", [format_kv(Key, Val) || {Key, Val} <- ItemList]),
     "}"];
 format_trace_output(_, Args) ->
     io_lib:format("~p", [Args]).
@@ -669,3 +669,13 @@ fun_to_ms(ShellFun) when is_function(ShellFun) ->
         false ->
             exit(shell_funs_only)
     end.
+
+-ifdef(OTP_RELEASE).
+-spec join(term(), [term()]) -> [term()].
+join(Sep, List) ->
+    lists:join(Sep, List).
+-else.
+-spec join(string(), [string()]) -> string().
+join(Sep, List) ->
+    string:join(List, Sep).
+-endif.

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -598,9 +598,10 @@ to_hms(_) ->
     {0,0,0}.
 
 format_args(Arity) when is_integer(Arity) ->
-    "/"++integer_to_list(Arity);
+    ["/", integer_to_list(Arity)];
 format_args(Args) when is_list(Args) ->
-    "("++string:join([recon_lib:format_trace_output(Arg) || Arg <- Args], ", ")++")".
+    Active = recon_rec:is_active(),
+    ["(", lists:join(", ", [recon_lib:format_trace_output(Active, Arg) || Arg <- Args]), ")"].
 
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -523,7 +523,7 @@ format(TraceMsg) ->
             {" '--> ~p:~p/~p", [M,F,Arity]};
         %% {trace, Pid, return_from, {M, F, Arity}, ReturnValue}
         {return_from, [{M,F,Arity}, Return]} ->
-            {"~p:~p/~p --> ~s", [M,F,Arity, recon_lib:format(Return)]};
+            {"~p:~p/~p --> ~s", [M,F,Arity, recon_lib:format_trace_output(Return)]};
         %% {trace, Pid, exception_from, {M, F, Arity}, {Class, Value}}
         {exception_from, [{M,F,Arity}, {Class,Val}]} ->
             {"~p:~p/~p ~p ~p", [M,F,Arity, Class, Val]};
@@ -600,7 +600,7 @@ to_hms(_) ->
 format_args(Arity) when is_integer(Arity) ->
     "/"++integer_to_list(Arity);
 format_args(Args) when is_list(Args) ->
-    "("++string:join([recon_lib:format(Arg) || Arg <- Args], ", ")++")".
+    "("++string:join([recon_lib:format_trace_output(Arg) || Arg <- Args], ", ")++")".
 
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -523,7 +523,7 @@ format(TraceMsg) ->
             {" '--> ~p:~p/~p", [M,F,Arity]};
         %% {trace, Pid, return_from, {M, F, Arity}, ReturnValue}
         {return_from, [{M,F,Arity}, Return]} ->
-            {"~p:~p/~p --> ~p", [M,F,Arity, Return]};
+            {"~p:~p/~p --> ~s", [M,F,Arity, recon_lib:format(Return)]};
         %% {trace, Pid, exception_from, {M, F, Arity}, {Class, Value}}
         {exception_from, [{M,F,Arity}, {Class,Val}]} ->
             {"~p:~p/~p ~p ~p", [M,F,Arity, Class, Val]};
@@ -600,8 +600,7 @@ to_hms(_) ->
 format_args(Arity) when is_integer(Arity) ->
     "/"++integer_to_list(Arity);
 format_args(Args) when is_list(Args) ->
-    "("++string:join([io_lib:format("~p", [Arg]) || Arg <- Args], ", ")++")".
-
+    "("++string:join([recon_lib:format(Arg) || Arg <- Args], ", ")++")".
 
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -619,8 +619,16 @@ format_trace_output(true, Args) when is_list(Args) ->
             L = lists:map(fun(A) -> format_trace_output(true, A) end, Args),
             "[" ++ string:join(L, ", ") ++ "]"
     end;
+format_trace_output(true, Args) when is_map(Args) ->
+    ItemList = maps:to_list(Args),
+    ["#{",
+        lists:join(", ", [format_kv(Key, Val) || {Key, Val} <- ItemList]),
+    "}"];
 format_trace_output(_, Args) ->
     io_lib:format("~p", [Args]).
+
+format_kv(Key, Val) ->
+    [format_trace_output(true, Key), "=", format_trace_output(true, Val)].
 
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%

--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -219,8 +219,8 @@ clear() ->
     erlang:trace(all, false, [all]),
     erlang:trace_pattern({'_','_','_'}, false, [local,meta,call_count,call_time]),
     erlang:trace_pattern({'_','_','_'}, false, []), % unsets global
-    maybe_kill(recon_trace_tracer),
-    maybe_kill(recon_trace_formatter),
+    recon_lib:maybe_kill(recon_trace_tracer),
+    recon_lib:maybe_kill(recon_trace_formatter),
     ok.
 
 %% @equiv calls({Mod, Fun, Args}, Max, [])
@@ -606,25 +606,6 @@ format_args(Args) when is_list(Args) ->
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%
 %%%%%%%%%%%%%%%
-
-maybe_kill(Name) ->
-    case whereis(Name) of
-        undefined ->
-            ok;
-        Pid ->
-            unlink(Pid),
-            exit(Pid, kill),
-            wait_for_death(Pid, Name)
-    end.
-
-wait_for_death(Pid, Name) ->
-    case is_process_alive(Pid) orelse whereis(Name) =:= Pid of
-        true ->
-            timer:sleep(10),
-            wait_for_death(Pid, Name);
-        false ->
-            ok
-    end.
 
 %% Borrowed from dbg
 fun_to_ms(ShellFun) when is_function(ShellFun) ->

--- a/test/recon_rec_SUITE.erl
+++ b/test/recon_rec_SUITE.erl
@@ -1,0 +1,58 @@
+-module(recon_rec_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-compile(export_all).
+
+
+%%%%%%%%%% SETUP
+
+all() -> [record_defs].
+
+init_per_suite(Config) ->
+    true = recon_rec:import(records1),
+    Config.
+
+end_per_suite(C) ->
+    whereis(recon_ets) ! stop,
+    C.
+
+init_per_testcase(_, Config) -> Config.
+
+end_per_testcase(_, Config) ->
+    recon_rec:clear(),
+    Config.
+
+%%%%%%%%%% TESTS
+
+record_defs(_Config) ->
+    has_record(state, 3), % make sure table was not wiped out
+    has_record(another, 3),
+    false = recon_rec:import(records2), %% one record is a duplicate
+    has_record(state, 3),
+    has_record(another, 3),
+    has_record(another, 4),
+    [Res] = recon_rec:lookup_record(state, 3),
+    check_first_field(aaa, Res),
+    recon_rec:clear(records1),
+    no_record(state, 3),
+    no_record(another, 3),
+    has_record(another, 4),
+    true = recon_rec:import(records2),
+    [Res1] = recon_rec:lookup_record(state, 3),
+    check_first_field(one, Res1),
+    recon_rec:clear(),
+    no_record(state, 3),
+    no_record(another, 3),
+    no_record(another, 4),
+    ok.
+
+%%%%%%%%%% HELPERS
+
+has_record(Name, Count) ->
+    [_] = recon_rec:lookup_record(Name, Count).
+
+no_record(Name, Count) ->
+    [] = recon_rec:lookup_record(Name, Count).
+
+check_first_field(F, Rec) ->
+    {_, Fields, _, _} = Rec,
+    {record_field, _, {atom, _, F}} = hd(Fields).

--- a/test/recon_rec_SUITE.erl
+++ b/test/recon_rec_SUITE.erl
@@ -51,17 +51,17 @@ lists_and_limits(_Config) ->
     recon_rec:import(records1),
     recon_rec:import(records2),
     List = recon_rec:get_list(),
-    [{records1,another,[ddd,eee,fff],all},
-     {records1,state,[aaa,bbb,ccc],all},
-     {records2,another,[one,two,three,four],all}] = List,
+    [{records1,another,[ddd,eee,fff],none},
+     {records1,state,[aaa,bbb,ccc],none},
+     {records2,another,[one,two,three,four],none}] = List,
     recon_rec:limit(another, 3, ddd),
-    {records1,another,[ddd,eee,fff], [ddd]} = hd(recon_rec:get_list()),
+    {records1,another,[ddd,eee,fff], ddd} = hd(recon_rec:get_list()),
     recon_rec:limit(another, 3, [ddd, eee]),
     {records1,another,[ddd,eee,fff], [ddd, eee]} = hd(recon_rec:get_list()),
     recon_rec:limit(another, 3, all),
     {records1,another,[ddd,eee,fff], all} = hd(recon_rec:get_list()),
     recon_rec:clear(records2),
-    {error, record_unknown} = recon_rec:limit(another, 4, all),
+    {error, record_unknown} = recon_rec:limit(another, 4, none),
     ok.
 
 %%%%%%%%%% HELPERS

--- a/test/recon_rec_SUITE.erl
+++ b/test/recon_rec_SUITE.erl
@@ -60,7 +60,7 @@ lists_and_limits(_Config) ->
     {records1,another,[ddd,eee,fff], [ddd, eee]} = hd(recon_rec:get_list()),
     recon_rec:limit(another, 3, all),
     {records1,another,[ddd,eee,fff], all} = hd(recon_rec:get_list()),
-    recon_rec:clear(record2),
+    recon_rec:clear(records2),
     {error, record_unknown} = recon_rec:limit(another, 4, all),
     ok.
 
@@ -74,4 +74,4 @@ no_record(Name, Count) ->
 
 check_first_field(F, Rec) ->
     {_, Fields, _, _} = Rec,
-    {record_field, _, {atom, _, F}} = hd(Fields).
+    F = hd(Fields).

--- a/test/records1.erl
+++ b/test/records1.erl
@@ -1,0 +1,13 @@
+-module(records1).
+-author("bartlomiej.gorny@erlang-solutions.com").
+%% API
+-export([state/3, another/3]).
+
+-record(state, {aaa, bbb, ccc}).
+-record(another, {ddd, eee, fff}).
+
+state(A, B, C) ->
+    #state{aaa = A, bbb = B, ccc = C}.
+
+another(D, E, F) ->
+    #another{ddd = D, eee = E, fff = F}.

--- a/test/records2.erl
+++ b/test/records2.erl
@@ -1,0 +1,13 @@
+-module(records2).
+-author("bartlomiej.gorny@erlang-solutions.com").
+%% API
+-export([state/3, another/4]).
+
+-record(state, {one, two, three}).
+-record(another, {one, two = something, three :: boolean(), four = 123 :: integer()}).
+
+state(A, B, C) ->
+    #state{one = A, two = B, three = C}.
+
+another(A, B, C, D) ->
+    #another{one = A, two = B, three = C, four = D}.


### PR DESCRIPTION
You tell recon where your record definitions are, and then recon_trace prints our records in a readable way, with field names. If you have big records then it saves lots and lots of time and effort.