### PR TITLE
fixed bug in filtering record fields for display

### DIFF
--- a/src/recon_rec.erl
+++ b/src/recon_rec.erl
@@ -240,7 +240,7 @@ apply_limits(_List, all) -> [];
 apply_limits(List, Field) when is_atom(Field) ->
     [{Field, proplists:get_value(Field, List)}, {more, '...'}];
 apply_limits(List, Limits) ->
-    [lists:filter(fun({K, _}) -> lists:member(K, Limits) end, List), {more, '...'}].
+    lists:filter(fun({K, _}) -> lists:member(K, Limits) end, List) ++ [{more, '...'}].
 
 %%%%%%%%%%%%%%%
 %%% HELPERS %%%


### PR DESCRIPTION
This PR fixes a minor bug which squashed all record fields if limit was defined as a list