### PR TITLE
Add minimal mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,13 @@
+defmodule Recon.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :recon,
+      description: "Diagnostic tools for production use",
+      version: "2.4.0",
+      language: :erlang,
+      deps: []
+    ]
+  end
+end

--- a/src/recon.app.src
+++ b/src/recon.app.src
@@ -9,5 +9,6 @@
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/ferd/recon/"},
            {"Documentation", "http://ferd.github.io/recon/"}]},
-  {files, ["src/", "script/", "rebar.lock", "README.md", "LICENSE"]}
+  {build_tools, ["mix", "rebar3"]},
+  {files, ["src/", "script/", "rebar.lock", "mix.exs", "README.md", "LICENSE"]}
 ]}.

--- a/src/recon.app.src
+++ b/src/recon.app.src
@@ -5,7 +5,6 @@
   {registered, []},
   {applications, [kernel, stdlib]},
 
-  {maintainers, ["Fred Hebert"]},
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/ferd/recon/"},
            {"Documentation", "http://ferd.github.io/recon/"}]},


### PR DESCRIPTION
The goal is to be able to use Recon is an Elixir/mix(1)-based project.

If the project can only be built with Rebar, mix(1) complains and asks if it can download `rebar3`. Not convenient in the middle of an unattended offline build.