### PR TITLE
Support extra message in traces

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -525,6 +525,9 @@ format(TraceMsg) ->
         %% {trace, Pid, call, {M, F, Args}}
         {call, [{M,F,Args}]} ->
             {"~p:~p~s", [M,F,format_args(Args)]};
+        %% {trace, Pid, call, {M, F, Args}, Msg}
+        {call, [{M,F,Args}, Msg]} ->
+            {"~p:~p~s ~s", [M,F,format_args(Args), format_trace_output(Msg)]};
         %% {trace, Pid, return_to, {M, F, Arity}}
         {return_to, [{M,F,Arity}]} ->
             {" '--> ~p:~p/~p", [M,F,Arity]};


### PR DESCRIPTION
Using the `message/1` action function in a match-spec sets an additional
message (aka the PAM result) appended to the trace message sent.