### PR TITLE
option io_server can also be an atom()

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -199,7 +199,7 @@
 -type options()      :: [ {pid, pidspec() | [pidspec(),...]} % default: all
                         | {timestamp, formatter | trace}     % default: formatter
                         | {args, args | arity}               % default: args
-                        | {io_server, pid()}                 % default: group_leader()
+                        | {io_server, pid() | atom()}        % default: group_leader()
                         | {formatter, formatterfun()}        % default: internal formatter
                         | return_to | {return_to, boolean()} % default: false
                    %% match pattern options


### PR DESCRIPTION
(not for dialyzer but human consumption)

Very minor thing: it happened to me that when I quickly looked at the option section of the docs online (http://ferd.github.io/recon/recon_trace.html#type-options) I initially thought that `io_server` option must be a pid (maybe recon does something special with it). I only later saw that the textual docs clearly state that it also can be an atom and looking at the code also makes this obvious.