### PR TITLE
Accumulate all block entries in format_blocks

### DIFF
--- a/src/recon_alloc.erl
+++ b/src/recon_alloc.erl
@@ -406,7 +406,9 @@ format_blocks(Alloc, Key, [{blocks, L} | List]) when is_list(L) ->
     MergeF = fun(K) ->
         fun({_A, Props}, Acc) ->
             case lists:keyfind(K, 1, Props) of
-                {K,Cur,Last,Max} -> {Cur, Last, Max};
+                {K,Cur,Last,Max} ->
+                    {AccCur, AccLast, AccMax} = Acc,
+                    {AccCur + Cur, AccLast + Last, AccMax + Max};
                 {K,V} -> Acc+V
             end
         end


### PR DESCRIPTION
Unless I'm mistaken (dealing with carriers in Erlang is not that easy), in `recon_alloc`, the `format_blocks`' `Acc` should be used when computing the total size and block count for an allocator. Otherwise, you get things like
```
  {mbcs,[{blocks,77,77,77},
          {blocks_size,7584,7584,7584},
          {foreign_blocks,[{ets_alloc,[{count,45,45,49},
                                       {size,45056,45056,46080}]},
                           {eheap_alloc,[{count,4,5,71},{size,243464,246480,246480}]},
                           {std_alloc,[{count,77,77,77},{size,7584,7584,7584}]}]},
          {raw_blocks,[{binary_alloc,[{count,1714,1715,1715},
                                      {size,1804080,1882840,1882840}]},
                       {ets_alloc,[{count,45,45,49},{size,45056,45056,46080}]},
                       {eheap_alloc,[{count,4,5,71},{size,243464,246480,246480}]},
                       {std_alloc,[{count,77,77,77},{size,7584,7584,7584}]}]},
```
when calling `recon_alloc:allocators/0` (and `recon_alloc:fragmentation/1`)
