### PR TITLE
Increase strictness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,4 @@ jobs:
       - run: rebar3 edoc
       - run: rebar3 eunit
       - run: rebar3 ct
+      - run: rebar3 dialyzer

--- a/src/recon.erl
+++ b/src/recon.erl
@@ -197,6 +197,7 @@ info(PidTerm) ->
 %%
 %% A fake attribute `binary_memory' is also available to return the
 %% amount of memory used by refc binaries for a process.
+-dialyzer({no_contracts, info/2}). % ... Overloaded contract for recon:info/2 has overlapping domains
 -spec info(pid_term(), info_type()) -> {info_type(), [{info_key(), term()}]}
     ;     (pid_term(), [atom()]) -> [{atom(), term()}]
     ;     (pid_term(), atom()) -> {atom(), term()}.
@@ -607,6 +608,7 @@ port_info(PortTerm) ->
 %% as defined in {@link port_info_type()}, and although the type signature
 %% doesn't show it in the generated documentation, individual items
 %% accepted by `erlang:port_info/2' are accepted, and lists of them too.
+-dialyzer({no_contracts, port_info/2}). % ... Overloaded contract for recon:port_info/2 has overlapping domains
 -spec port_info(port_term(), port_info_type()) -> {port_info_type(),
                                                    [{port_info_key(), _}]}
     ;          (port_term(), [atom()]) -> [{atom(), term()}]


### PR DESCRIPTION
While trying to check if we'd run into errors come OTP 24, I figured I could get rid of the last remaining `dialyzer`-issued warnings, which is why I included it in CI.

(we'd [discussed this issue, around 2 years ago](https://github.com/ferd/recon/issues/70), but at that time I didn't remember this solution)