### PR TITLE
Include erts_mmap in snapshot to help debug VM issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       image: erlang:${{matrix.otp_vsn}}
     strategy:
       matrix:
-        otp_vsn: ['18.3', '19.3', '20.3', '21.3', '22.3', '23.3', '24.0', '25.0']
+        otp_vsn: ['18.3', '19.3', '20.3', '21.3', '22.3', '23.3', '24.3', '25.3', '26.0.2']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/src/recon.erl
+++ b/src/recon.erl
@@ -514,6 +514,7 @@ source(Module) ->
     Path = code:which(Module),
     {ok,{_,[{abstract_code,{_,AC}}]}} = beam_lib:chunks(Path, [abstract_code]),
     erl_prettypr:format(erl_syntax:form_list(AC)).
+-dialyzer({nowarn_function, source/1}).
 
 %%% Ports Info %%%
 


### PR DESCRIPTION
While investigating a virtual memory issue I found that none of the supercarrier statistics were included in the snapshot. This PR includes those.