### PR TITLE
remove compilation warning in OTP26.1

### DIFF
--- a/src/recon_alloc.erl
+++ b/src/recon_alloc.erl
@@ -703,7 +703,7 @@ weighed_values({SbcsBlockSize, SbcsCarrierSize},
 %% but also takes 0/0 to be 100% to make working with sorting and
 %% weights simpler.
 usage(0,0) -> 1.00;
-usage(0.0,0.0) -> 1.00;
+usage(+0.0,+0.0) -> 1.00;
 %usage(N,0) -> ???;
 usage(Block,Carrier) -> Block/Carrier.
 


### PR DESCRIPTION
In OTP-27, `+0.0` and `-0.0` will no longer be the exact number so they added a compilation warning in OTP-26.1 to warn when a float 0.0 is getting match without specifying the sign:

```
rebar3 compile                                                                                                                                                                               0s
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling recon
src/recon_alloc.erl:706:7: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/recon_alloc.erl:706:11: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
```

Longer explanation about why are not the same [1]

Pull request adding the warning [2]

[1] https://erlangforums.com/t/in-erlang-otp-27-0-0-will-no-longer-be-exactly-equal-to-0-0/2586
[2] https://github.com/erlang/otp/pull/7521