### PR TITLE
Add missing dependency on syntax_tools

### DIFF
--- a/src/recon.app.src
+++ b/src/recon.app.src
@@ -3,7 +3,7 @@
   {vsn, "2.5.5"},
   {modules, [recon, recon_alloc, recon_lib, recon_trace, recon_rec]},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, syntax_tools]},
 
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/ferd/recon/"},


### PR DESCRIPTION
The `recon:source/1` function calls `erl_prettypr` from `syntax_tools` application. This dependency was missing from the `.app` - this resulting in incomplete builds in some cases