### PR TITLE
Bump CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       image: erlang:${{matrix.otp_vsn}}
     strategy:
       matrix:
-        otp_vsn: ['18.3', '19.3', '20.3', '21.3', '22.3', '23.3', '24.3', '25.3', '26.0.2']
+        otp_vsn: ['20.3', '21.3', '22.3', '23.3', '24.3', '25.3', '26.0.2', '27.0.1']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Some stuff is so old that containers no longer contain library versions required to run dependencies.