### PR TITLE
Optimize (not) printing empty string from formatter

### DIFF
--- a/src/recon_trace.erl
+++ b/src/recon_trace.erl
@@ -393,7 +393,10 @@ formatter(Tracer, IOServer, FormatterFun) ->
         {'EXIT', Tracer, Reason} ->
             exit(Reason);
         TraceMsg ->
-            io:format(IOServer, FormatterFun(TraceMsg), []),
+            case FormatterFun(TraceMsg) of
+                "" -> ok;
+                Formatted -> io:format(IOServer, Formatted, [])
+            end,
             formatter(Tracer, IOServer, FormatterFun)
     end.
 


### PR DESCRIPTION
Sometimes it is handy to implement some additional filtering in a custom formatter function. In this case the formatter can return the empty string if it wants to ignore a trace message. Optimize the formatting so in the empty string case it does not send an io request to the IO server. This saves some message passing and avoids a "flickering prompt" effect (when the empty string is printed) in case of 1000s of ignored trace messages per second.

Tested manually in `rebar3 shell` (before this patch prompt `4>` used to "flicker"):
```
1> F = fun F() -> lists:nth(2, [1,2,3]), timer:sleep(1), F() end.
#Fun<erl_eval.20.125776118>
2> spawn(fun() -> F() end).
<0.198.0>
3> recon_trace:calls({lists, nth, 2}, 1000, [{formatter, fun(_) -> "" end}]).
1
Recon tracer rate limit tripped.
4>
```