### PR TITLE
Prevent crash when calling binary_memory on a dead process

### DIFF
--- a/src/recon.erl
+++ b/src/recon.erl
@@ -240,8 +240,10 @@ proc_info(Pid, List) when is_list(List) ->
         false ->
             erlang:process_info(Pid, List);
         true ->
-            Res = erlang:process_info(Pid, replace(binary_memory, binary, List)),
-            proc_fake(List, Res)
+            case erlang:process_info(Pid, replace(binary_memory, binary, List)) of
+                undefined -> undefined;
+                Res when is_list(Res) -> proc_fake(List, Res)
+            end
     end.
 
 %% @private Replace keys around

--- a/test/recon_SUITE.erl
+++ b/test/recon_SUITE.erl
@@ -315,7 +315,14 @@ binary_memory(_Config) ->
     Res2 = recon:info(Pid2, [binary_memory, binary, binary_memory]),
     %% we expect everything to look as a single call to process_info/2
     [{binary,X}, {binary_memory,_}, {binary,X}] = Res1,
-    [{binary_memory,Y}, {binary,_}, {binary_memory,Y}] = Res2.
+    [{binary_memory,Y}, {binary,_}, {binary_memory,Y}] = Res2,
+    %% make sure we deal with dead processes fine
+    {Pid, Ref} = spawn_monitor(fun() -> ok end),
+    receive
+        {'DOWN', Ref, _, _, _} -> ok
+    end,
+    ?assertEqual(undefined, recon:info(Pid, [binary_memory])),
+    ok.
 
 %% Just check that we get many schedulers and that the usage values are all
 %% between 0 and 1 inclusively. We don't care for edge cases like a


### PR DESCRIPTION
Fixes https://github.com/ferd/recon/issues/95